### PR TITLE
date mapper fix

### DIFF
--- a/src/main/java/com/typemapper/core/fieldMapper/DateFieldMapper.java
+++ b/src/main/java/com/typemapper/core/fieldMapper/DateFieldMapper.java
@@ -2,20 +2,36 @@ package com.typemapper.core.fieldMapper;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.apache.log4j.Logger;
 
 public class DateFieldMapper implements FieldMapper {
-	
-	private static final Logger LOG = Logger.getLogger(DateFieldMapper.class); 
+
+	private static final Logger LOG = Logger.getLogger(DateFieldMapper.class);
+
+	private static final String[] FORMATS = { "yyyy-MM-dd k:m:s",
+			"yyyy-MM-dd k:m", "yyyy-MM-dd" };
 
 	@Override
 	public Object mapField(String string, Class clazz) {
-		try {
-			return new SimpleDateFormat("yyyy-MM-dd k:m:s").parse(string);
-		} catch (ParseException e) {
-			LOG.error("Could not parse date: " + string, e);
-			return null;
+		Date result = null;
+		for (final String format : FORMATS) {
+			try {
+				result = new SimpleDateFormat(format).parse(string);
+				if (result != null) {
+					break;
+				}
+			} catch (ParseException e) {
+			}
+		}
+		if (result == null) {
+			LOG.error("Could not parse date: " + string);
+		}
+		if (clazz != null && clazz.equals(java.sql.Date.class) && result != null) {
+			return new java.sql.Date(result.getTime());
+		} else {
+			return result;
 		}
 	}
 

--- a/src/test/java/com/typemapper/core/fieldMapper/DateFieldMapperTest.java
+++ b/src/test/java/com/typemapper/core/fieldMapper/DateFieldMapperTest.java
@@ -1,0 +1,31 @@
+package com.typemapper.core.fieldMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.sql.Date;
+
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+@RunWith(Theories.class)
+public class DateFieldMapperTest {
+
+	@DataPoints
+	public static final String[] DATES = { "2011-11-11 11:11:11",
+			"2011-11-11 11:11", "2011-11-11" };
+
+	@DataPoints
+	public static final Class<?>[] CLASSES = { Date.class, java.util.Date.class };
+
+	private static final DateFieldMapper MAPPER = new DateFieldMapper();
+
+	@Theory
+	public void parseAble(final String string, final Class<?> clazz) throws Exception {
+		Object result = MAPPER.mapField(string, clazz);
+		assertNotNull(result);
+		assertEquals(result.getClass(), clazz);
+	}
+}

--- a/src/test/java/com/typemapper/core/fieldMapper/DateFieldMapperValuesTest.java
+++ b/src/test/java/com/typemapper/core/fieldMapper/DateFieldMapperValuesTest.java
@@ -1,0 +1,50 @@
+package com.typemapper.core.fieldMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.junit.Test;
+
+public class DateFieldMapperValuesTest {
+
+	private static final DateFieldMapper MAPPER = new DateFieldMapper();
+
+	private static final String DATE_STRING = "2011-11-11 11:11:11";
+
+	@Test
+	public void testHourAndMinute() throws Exception {
+		Date result = (Date) MAPPER.mapField(DATE_STRING, Date.class);
+		assertEquals(DATE_STRING,
+				new SimpleDateFormat("yyyy-MM-dd k:m:s").format(result));
+	}
+
+	@Test
+	public void wrongInputShouldYieldNull() throws Exception {
+		assertNull(MAPPER.mapField("foo", Date.class));
+	}
+
+	@Test
+	public void nullClassDoesNotBorkMethod() throws Exception {
+		Object result = MAPPER.mapField(DATE_STRING, null);
+		assertNotNull(result);
+		assertEquals(Date.class, result.getClass());
+	}
+
+	@Test
+	public void wrongClassDoesNotBorkMethod() throws Exception {
+		Object result = MAPPER.mapField(DATE_STRING, String.class);
+		assertNotNull(result);
+		assertEquals(Date.class, result.getClass());
+	}
+
+	@Test
+	public void sqlDateClassReturnsCorrectObject() throws Exception {
+		Object result = MAPPER.mapField(DATE_STRING, java.sql.Date.class);
+		assertNotNull(result);
+		assertEquals(java.sql.Date.class, result.getClass());
+	}
+}


### PR DESCRIPTION
- the mapper could not parse dates only timestamps
- the mapper will return java.util.Date or java.sql.Date depending on
  the input parameter
