### PR TITLE
Added support for enumeration type in postgres.

### DIFF
--- a/src/main/java/com/typemapper/core/TypeMapper.java
+++ b/src/main/java/com/typemapper/core/TypeMapper.java
@@ -136,7 +136,10 @@ public class TypeMapper<ITEM> implements ParameterizedRowMapper<ITEM> {
             try {
                 final DbResultNode node = tree.getChildByName(mapping.getName());
                 if (node == null) {
-                    LOG.error("Could not map property " + mapping.getName() + " of class " + resultClass
+
+                    // this may be okay - if any return value is NULL, we will reach this path.
+                    // to classify and mark this as an error, we need more information.
+                    LOG.debug("Could not map property " + mapping.getName() + " of class " + resultClass
                             .getSimpleName() + ": field not in result tree");
                     continue;
                 }

--- a/src/main/java/com/typemapper/core/fieldMapper/FieldMapperRegister.java
+++ b/src/main/java/com/typemapper/core/fieldMapper/FieldMapperRegister.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class FieldMapperRegister {
 
@@ -62,6 +63,9 @@ public class FieldMapperRegister {
 
         final FieldMapper nullListMapper = new NullListFieldMapper();
         FieldMapperRegister.register(List.class, nullListMapper);
+
+        final FieldMapper nullSetMapper = new NullSetFieldMapper();
+        FieldMapperRegister.register(Set.class, nullSetMapper);
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/main/java/com/typemapper/core/fieldMapper/NullSetFieldMapper.java
+++ b/src/main/java/com/typemapper/core/fieldMapper/NullSetFieldMapper.java
@@ -1,0 +1,16 @@
+package com.typemapper.core.fieldMapper;
+
+/**
+ * sentinel mapper for NULL fields returned from database for Set<?> mappings to avoid "Could not find mapper for type
+ * java.util.Set" exceptions.
+ *
+ * @author  carsten.wolters
+ */
+public class NullSetFieldMapper implements FieldMapper {
+
+    @Override
+    public Object mapField(final String string, final Class<?> clazz) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/typemapper/core/fieldMapper/ObjectFieldMapper.java
+++ b/src/main/java/com/typemapper/core/fieldMapper/ObjectFieldMapper.java
@@ -18,6 +18,7 @@ public class ObjectFieldMapper {
 
     private static final Logger LOG = Logger.getLogger(ObjectFieldMapper.class);
 
+    @SuppressWarnings("unchecked")
     public static final Object mapField(@SuppressWarnings("rawtypes") final Class clazz, final ObjectResultNode node)
         throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NotsupportedTypeException {
@@ -25,27 +26,37 @@ public class ObjectFieldMapper {
             return null;
         }
 
-        List<Mapping> mappings = Mapping.getMappingsForClass(clazz);
-        Object result = clazz.newInstance();
+        Object result = null;
 
-        for (Mapping mapping : mappings) {
-            DbResultNode currentNode = node.getChildByName(mapping.getName());
-            if (currentNode == null) {
-                LOG.warn("Could not find value of mapping: " + mapping.getName());
-                continue;
-            }
+        // instantiate enums by string value
+        if (clazz.isEnum()) {
+            final DbResultNode currentNode = node.getChildByName(node.getType());
+            result = Enum.valueOf(clazz, currentNode.getValue());
+        } else {
+            result = clazz.newInstance();
 
-            try {
-                if (DbResultNodeType.SIMPLE.equals(currentNode.getNodeType())) {
-                    mapping.map(result,
-                        mapping.getFieldMapper().mapField(currentNode.getValue(), mapping.getFieldClass()));
-                } else if (DbResultNodeType.OBJECT.equals(currentNode.getNodeType())) {
-                    mapping.map(result, mapField(mapping.getFieldClass(), (ObjectResultNode) currentNode));
-                } else if (DbResultNodeType.ARRAY.equals(currentNode.getNodeType())) {
-                    mapping.map(result, ArrayFieldMapper.mapField(mapping.getField(), (ArrayResultNode) currentNode));
+            final List<Mapping> mappings = Mapping.getMappingsForClass(clazz);
+
+            for (final Mapping mapping : mappings) {
+                final DbResultNode currentNode = node.getChildByName(mapping.getName());
+                if (currentNode == null) {
+                    LOG.warn("Could not find value of mapping: " + mapping.getName());
+                    continue;
                 }
-            } catch (Exception e) {
-                LOG.error("Failed to map property " + mapping.getName() + " of class " + clazz.getSimpleName(), e);
+
+                try {
+                    if (DbResultNodeType.SIMPLE.equals(currentNode.getNodeType())) {
+                        mapping.map(result,
+                            mapping.getFieldMapper().mapField(currentNode.getValue(), mapping.getFieldClass()));
+                    } else if (DbResultNodeType.OBJECT.equals(currentNode.getNodeType())) {
+                        mapping.map(result, mapField(mapping.getFieldClass(), (ObjectResultNode) currentNode));
+                    } else if (DbResultNodeType.ARRAY.equals(currentNode.getNodeType())) {
+                        mapping.map(result,
+                            ArrayFieldMapper.mapField(mapping.getField(), (ArrayResultNode) currentNode));
+                    }
+                } catch (final Exception e) {
+                    LOG.error("Failed to map property " + mapping.getName() + " of class " + clazz.getSimpleName(), e);
+                }
             }
         }
 

--- a/src/main/java/com/typemapper/core/result/ObjectResultNode.java
+++ b/src/main/java/com/typemapper/core/result/ObjectResultNode.java
@@ -2,6 +2,7 @@ package com.typemapper.core.result;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,97 +11,105 @@ import org.apache.log4j.Logger;
 import com.typemapper.core.db.DbType;
 import com.typemapper.core.db.DbTypeField;
 import com.typemapper.core.db.DbTypeRegister;
+
 import com.typemapper.parser.exception.RowParserException;
 import com.typemapper.parser.postgres.ParseUtils;
 
 public class ObjectResultNode implements DbResultNode {
-	
-	private static final Logger LOG = Logger.getLogger(ObjectResultNode.class);
-	
-	private String name;
-	private String type;
-	private List<DbResultNode> children; 
-	
-	public ObjectResultNode(String value, String name, String typeName, Connection connection) throws SQLException {
-		super();
-		this.type = typeName;
-		this.children = new ArrayList<DbResultNode>();
-		this.name = name;
-		List<String> values;
-		if (value == null) {
-			children = null;
-			return;
-		}
-		try {
-			values = ParseUtils.postgresROW2StringList(value);
-		} catch (RowParserException e) {
-			throw new SQLException(e);
-		}
-		DbType dbType = DbTypeRegister.getDbType(typeName, connection);
-		int i = 1;
-		for (String fieldValue : values) {
-			DbTypeField fieldDef = dbType.getFieldByPos(i);
-			DbResultNode node = null;
-			if (fieldDef == null) {
-				LOG.error("Could not find field in " + dbType + " for pos " + i);
-				continue;
-			}
-			if (fieldDef.getType().equals("USER-DEFINED")) {
-                if(fieldDef.getTypeName().equals("hstore")){
+
+    private static final Logger LOG = Logger.getLogger(ObjectResultNode.class);
+
+    private String name;
+    private String type;
+    private List<DbResultNode> children;
+
+    public ObjectResultNode(final String value, final String name, final String typeName, final Connection connection)
+        throws SQLException {
+        super();
+        this.type = typeName;
+        this.children = new ArrayList<DbResultNode>();
+        this.name = name;
+
+        List<String> values;
+        if (value == null) {
+            children = null;
+            return;
+        }
+
+        try {
+            values = ParseUtils.postgresROW2StringList(value);
+        } catch (final RowParserException e) {
+            throw new SQLException(e);
+        }
+
+        final DbType dbType = DbTypeRegister.getDbType(typeName, connection);
+        int i = 1;
+        for (final String fieldValue : values) {
+            final DbTypeField fieldDef = dbType.getFieldByPos(i);
+            DbResultNode node = null;
+            if (fieldDef == null) {
+                LOG.error("Could not find field in " + dbType + " for pos " + i);
+                continue;
+            }
+
+            if (fieldDef.getType().equals("USER-DEFINED")) {
+                if (fieldDef.getTypeName().equals("hstore")) {
+                    node = new SimpleResultNode(fieldValue, fieldDef.getName());
+                } else if (fieldDef.getTypeName().equals("enumeration")) {
                     node = new SimpleResultNode(fieldValue, fieldDef.getName());
                 } else {
                     node = new ObjectResultNode(fieldValue, fieldDef.getName(), fieldDef.getTypeName(), connection);
                 }
-			} else if (fieldDef.getType().equals("ARRAY")) {
-				node = new ArrayResultNode(fieldDef.getName(), fieldValue, fieldDef.getTypeName().substring(1), connection);
-			} else {
-				node = new SimpleResultNode(fieldValue, fieldDef.getName());
-			}
-			this.children.add(node);
-			i++;
-		}
-	}
-	
-	public String getType() {
-		return type;
-	}
+            } else if (fieldDef.getType().equals("ARRAY")) {
+                node = new ArrayResultNode(fieldDef.getName(), fieldValue, fieldDef.getTypeName().substring(1),
+                        connection);
+            } else {
+                node = new SimpleResultNode(fieldValue, fieldDef.getName());
+            }
 
-	@Override
-	public DbResultNodeType getNodeType() {
-		return DbResultNodeType.OBJECT;
-	}
+            this.children.add(node);
+            i++;
+        }
+    }
 
-	@Override
-	public String getValue() {
-		return null;
-	}
+    public String getType() {
+        return type;
+    }
 
-	@Override
-	public List<DbResultNode> getChildren() {
-		return children;
-	}
+    @Override
+    public DbResultNodeType getNodeType() {
+        return DbResultNodeType.OBJECT;
+    }
 
-	@Override
-	public String getName() {
-		return this.name;
-	}
+    @Override
+    public String getValue() {
+        return null;
+    }
 
-	@Override
-	public DbResultNode getChildByName(String name) {
-		for (DbResultNode node : getChildren()) {
-			if (node.getName().equals(name)) {
-				return node;
-			}
-		}
-		return null;
-	}
+    @Override
+    public List<DbResultNode> getChildren() {
+        return children;
+    }
 
+    @Override
+    public String getName() {
+        return this.name;
+    }
 
+    @Override
+    public DbResultNode getChildByName(final String name) {
+        for (final DbResultNode node : getChildren()) {
+            if (node.getName().equals(name)) {
+                return node;
+            }
+        }
 
-	@Override
-	public String toString() {
-		return "ObjectResultNode [name=" + name + ", type=" + type
-				+ ", children=" + children + "]";
-	}
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectResultNode [name=" + name + ", type=" + type + ", children=" + children + "]";
+    }
 
 }

--- a/src/main/java/com/typemapper/parser/postgres/ParseUtils.java
+++ b/src/main/java/com/typemapper/parser/postgres/ParseUtils.java
@@ -34,9 +34,9 @@ public class ParseUtils {
 
         // This is a simple copy-paste from the ROW processing code, and
         // strictly speaking is not quite correct for PostgreSQL ARRAYs
-        List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<String>();
 
-        char[] c = value.toCharArray();
+        final char[] c = value.toCharArray();
 
         StringBuilder element = new StringBuilder(appendStringSize);
 
@@ -45,7 +45,7 @@ public class ParseUtils {
         int i = 1;
         while (c[i] != '}') {
             if (c[i] == ',') {
-                char nextChar = c[i + 1];
+                final char nextChar = c[i + 1];
                 if (nextChar == ',' || nextChar == '}') {
 
                     throw new ArrayParserException("Empty array value at position " + i + " should be quoted: "
@@ -58,7 +58,7 @@ public class ParseUtils {
 
                 boolean insideQuote = true;
                 while (insideQuote) {
-                    char nextChar = c[i + 1];
+                    final char nextChar = c[i + 1];
                     if (c[i] == '\"') {
                         if (nextChar == ',' || nextChar == '}') {
                             result.add(element.toString());
@@ -106,16 +106,23 @@ public class ParseUtils {
         return postgresROW2StringList(value, 16);
     }
 
-    public static final List<String> postgresROW2StringList(final String value, final int appendStringSize)
+    public static final List<String> postgresROW2StringList(String value, final int appendStringSize)
         throws RowParserException {
-        if (!(value.startsWith("(") && value.endsWith(")"))) {
+        if ((value.startsWith("(") && !value.endsWith(")")) || (!value.startsWith("(") && value.endsWith(")"))) {
             throw new RowParserException("postgresROW2StringList() ROW must begin with '(' and ends with ')': "
                     + value);
         }
 
-        List<String> result = new ArrayList<String>();
+        if (!(value.startsWith("(") || value.endsWith(")"))) {
 
-        char[] c = value.toCharArray();
+            // in case both elements are missing, we add them for processing:
+            // this will be the case for enum types:
+            value = "(" + value + ")";
+        }
+
+        final List<String> result = new ArrayList<String>();
+
+        final char[] c = value.toCharArray();
 
         StringBuilder element = new StringBuilder(appendStringSize);
 
@@ -124,7 +131,7 @@ public class ParseUtils {
         int i = 1;
         while (c[i] != ')') {
             if (c[i] == ',') {
-                char nextChar = c[i + 1];
+                final char nextChar = c[i + 1];
                 if (c[i - 1] == '(') {
 
                     // we have an empty first position, that is we have a NULL value
@@ -141,7 +148,7 @@ public class ParseUtils {
 
                 boolean insideQuote = true;
                 while (insideQuote) {
-                    char nextChar = c[i + 1];
+                    final char nextChar = c[i + 1];
                     if (c[i] == '\"') {
                         if (nextChar == ',' || nextChar == ')') {
                             result.add(element.toString());
@@ -190,7 +197,7 @@ public class ParseUtils {
             return null;
         }
 
-        String b = s.trim().toLowerCase(Locale.US).intern();
+        final String b = s.trim().toLowerCase(Locale.US).intern();
         for (int i = 0; i < 3; i++) {
             if (b.equals(trueList[i])) {
                 return Boolean.TRUE;

--- a/src/main/java/com/typemapper/postgres/PgTypeHelper.java
+++ b/src/main/java/com/typemapper/postgres/PgTypeHelper.java
@@ -206,6 +206,11 @@ public class PgTypeHelper {
 
     public static PgTypeDataHolder getObjectAttributesForPgSerialization(final Object obj, final String typeHint,
             final Connection connection) {
+        return getObjectAttributesForPgSerialization(obj, typeHint, connection, false);
+    }
+
+    public static PgTypeDataHolder getObjectAttributesForPgSerialization(final Object obj, final String typeHint,
+            final Connection connection, final boolean forceTypeHint) {
         if (obj == null) {
             throw new NullPointerException();
         }
@@ -221,9 +226,10 @@ public class PgTypeHelper {
             typeName = databaseType.name();
         }
 
-        if (typeName == null || typeName.isEmpty()) {
+        if (typeName == null || typeName.isEmpty() || forceTypeHint) {
 
-            // if no annotation is given use the typehint parameter
+            // if no annotation is given use the type hint parameter
+            // use type hint if forceTypeHint is set to true
             typeName = typeHint;
         }
 
@@ -373,7 +379,7 @@ public class PgTypeHelper {
                 sb.append(PgArray.ARRAY((Object[]) o).toString());
             }
         } else if (clazz.isEnum()) {
-            sb.append(((Enum) o).name());
+            sb.append(((Enum<?>) o).name());
         } else if (o instanceof Date) {
             sb.append(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S").format((Date) o));
         } else if (o instanceof Map) {
@@ -409,4 +415,8 @@ public class PgTypeHelper {
         return new PgRow(getObjectAttributesForPgSerialization(o, typeHint, connection), connection);
     }
 
+    public static PgRow asPGobject(final Object o, final String typeHint, final Connection connection,
+            final boolean forceTypeHint) throws SQLException {
+        return new PgRow(getObjectAttributesForPgSerialization(o, typeHint, connection, forceTypeHint), connection);
+    }
 }

--- a/src/test/java/com/typemapper/AbstractTest.java
+++ b/src/test/java/com/typemapper/AbstractTest.java
@@ -3,6 +3,7 @@ package com.typemapper;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+
 import java.util.Properties;
 
 import org.junit.After;
@@ -20,12 +21,14 @@ public class AbstractTest {
 
     @Before
     public void setUp() throws Exception {
+
         // Get connection
         Class.forName("org.postgresql.Driver");
-        String url = "jdbc:postgresql://localhost/postgres";
-        Properties props = new Properties();
-        props.setProperty("user","postgres");
-        props.setProperty("password","postgres");
+
+        final String url = "jdbc:postgresql://localhost/postgres";
+        final Properties props = new Properties();
+        props.setProperty("user", "postgres");
+        props.setProperty("password", "postgres");
         connection = DriverManager.getConnection(url, props);
         execute("DROP SCHEMA IF EXISTS tmp CASCADE;");
         execute("DROP SCHEMA IF EXISTS tmp2 CASCADE;");
@@ -42,124 +45,85 @@ public class AbstractTest {
         execute("CREATE TYPE tmp.array_type AS (arr tmp.simple_type[], str varchar);");
         execute("CREATE TYPE tmp.hstore_type AS (map hstore, str varchar);");
         execute("CREATE TYPE tmp.hstore_array_type AS (map_array hstore[], str varchar);");
+
+        execute("CREATE TYPE tmp.enumeration AS ENUM ('VALUE_1', 'VALUE_2')");
+        execute("CREATE TYPE tmp.simple_enumeration_type AS (a enumeration, b enumeration);");
+        execute("CREATE TYPE tmp.simple_with_enumeration_type AS (a enumeration, b enumeration, str varchar);");
+
         execute("CREATE TABLE tmp.simple_table (i int, l int, c varchar);");
         execute("INSERT INTO tmp.simple_table (i, l, c) VALUES (1,2,'Daniel'), (2,3,'alone at'), (3,4,'home');");
-        String primitive_sproc = 	"CREATE OR REPLACE FUNCTION tmp.primitives_function(OUT id smallint, OUT msg text) " +
-                "RETURNS record AS " +
-                "$BODY$ " +
-                "DECLARE " +
-                "BEGIN " +
-                "id  := 0; " +
-                "msg := 'result_code'; " +
-                "RETURN; " +
-                "END " +
-                " $BODY$ " +
-                " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+
+        final String primitive_sproc =
+            "CREATE OR REPLACE FUNCTION tmp.primitives_function(OUT id smallint, OUT msg text) " + "RETURNS record AS "
+                + "$BODY$ " + "DECLARE " + "BEGIN " + "id  := 0; " + "msg := 'result_code'; " + "RETURN; " + "END "
+                + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
 
         execute(primitive_sproc);
 
-        String sproc_with_null_result = "CREATE OR REPLACE FUNCTION tmp.primitives_with_null_function(OUT id smallint, OUT msg text) " +
-                "RETURNS record AS " +
-                "$BODY$ " +
-                "DECLARE " +
-                "BEGIN " +
-                "id  := 0; " +
-                "RETURN; " +
-                "END " +
-                " $BODY$ " +
-                " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+        final String sproc_with_null_result =
+            "CREATE OR REPLACE FUNCTION tmp.primitives_with_null_function(OUT id smallint, OUT msg text) "
+                + "RETURNS record AS " + "$BODY$ " + "DECLARE " + "BEGIN " + "id  := 0; " + "RETURN; " + "END "
+                + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
         execute(sproc_with_null_result);
 
-        String primitive_sproc_2 = 	"CREATE OR REPLACE FUNCTION tmp2.primitives_function(OUT id smallint, OUT msg text, OUT msg2 text) " +
-                "RETURNS record AS " +
-                "$BODY$ " +
-                "DECLARE " +
-                "BEGIN " +
-                "id  := 0; " +
-                "msg := 'result_code'; " +
-                "msg2 := 'result_code_2'; " +
-                "RETURN; " +
-                "END " +
-                " $BODY$ " +
-                " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+        final String primitive_sproc_2 =
+            "CREATE OR REPLACE FUNCTION tmp2.primitives_function(OUT id smallint, OUT msg text, OUT msg2 text) "
+                + "RETURNS record AS " + "$BODY$ " + "DECLARE " + "BEGIN " + "id  := 0; " + "msg := 'result_code'; "
+                + "msg2 := 'result_code_2'; " + "RETURN; " + "END " + " $BODY$ "
+                + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
         execute(primitive_sproc_2);
 
+        final String array_sproc =
+            "CREATE OR REPLACE FUNCTION tmp.array_function(OUT id smallint, OUT msg text, OUT movies tmp.simple_type[]) "
+                + "RETURNS record AS " + "$BODY$ " + "DECLARE " + "BEGIN " + "id  := 0; " + "msg := 'result_code'; "
+                + "movies := ARRAY(SELECT ROW(i,l,c)::tmp.simple_type FROM tmp.simple_table ORDER BY i); " + "RETURN; "
+                + "END " + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
 
-        String array_sproc = 	"CREATE OR REPLACE FUNCTION tmp.array_function(OUT id smallint, OUT msg text, OUT movies tmp.simple_type[]) " +
-                "RETURNS record AS " +
-                "$BODY$ " +
-                "DECLARE " +
-                "BEGIN " +
-                "id  := 0; " +
-                "msg := 'result_code'; " +
-                "movies := ARRAY(SELECT ROW(i,l,c)::tmp.simple_type FROM tmp.simple_table ORDER BY i); " +
-                "RETURN; " +
-                "END " +
-                " $BODY$ " +
-                " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
-        
         execute(array_sproc);
-        String string_array_sproc = 	"CREATE OR REPLACE FUNCTION tmp.string_array_function(OUT str text, OUT arr text[]) " +
-        "RETURNS record AS " +
-        "$BODY$ " +
-        "DECLARE " +
-        "BEGIN " +
-        "str := 'str'; " +
-        "arr := ARRAY['result_1','result_2']; " +
-        "RETURN; " +
-        "END " +
-        " $BODY$ " +
-        " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+
+        final String string_array_sproc =
+            "CREATE OR REPLACE FUNCTION tmp.string_array_function(OUT str text, OUT arr text[]) " + "RETURNS record AS "
+                + "$BODY$ " + "DECLARE " + "BEGIN " + "str := 'str'; " + "arr := ARRAY['result_1','result_2']; "
+                + "RETURN; " + "END " + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
 
         execute(string_array_sproc);
-        
-        String string_null_array_sproc = 	"CREATE OR REPLACE FUNCTION tmp.string_null_array_function(OUT str text, OUT arr text[]) " +
-        "RETURNS record AS " +
-        "$BODY$ " +
-        "DECLARE " +
-        "BEGIN " +
-        "str := 'str'; " +
-        "RETURN; " +
-        "END " +
-        " $BODY$ " +
-        " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+
+        final String string_null_array_sproc =
+            "CREATE OR REPLACE FUNCTION tmp.string_null_array_function(OUT str text, OUT arr text[]) "
+                + "RETURNS record AS " + "$BODY$ " + "DECLARE " + "BEGIN " + "str := 'str'; " + "RETURN; " + "END "
+                + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
 
         execute(string_null_array_sproc);
-        
-        String hstore_type_sproc = "CREATE OR REPLACE FUNCTION tmp.hstore_type_function(OUT aa tmp.hstore_type, OUT bb text) " +
-                "RETURNS record AS " +
-                "$BODY$ " +
-                "DECLARE " +
-                "BEGIN " +
-                "aa := CAST (ROW( hstore('key','val'), 'str') AS tmp.hstore_type); " +
-                "bb := 'temp';" +
-                "RETURN ; " +
-                "END " +
-                " $BODY$ " +
-                " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
-        
+
+        final String hstore_type_sproc =
+            "CREATE OR REPLACE FUNCTION tmp.hstore_type_function(OUT aa tmp.hstore_type, OUT bb text) "
+                + "RETURNS record AS " + "$BODY$ " + "DECLARE " + "BEGIN "
+                + "aa := CAST (ROW( hstore('key','val'), 'str') AS tmp.hstore_type); " + "bb := 'temp';" + "RETURN ; "
+                + "END " + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+
         execute(hstore_type_sproc);
 
-        String hstore_array_type_sproc = "CREATE OR REPLACE FUNCTION tmp.hstore_array_type_function(OUT aa tmp.hstore_array_type, OUT bb text) " +
-                "RETURNS record AS " +
-                "$BODY$ " +
-                "DECLARE " +
-                "BEGIN " +
-                "aa := CAST ( ROW( ARRAY[ hstore('key','val') ], 'str') AS tmp.hstore_array_type); " +
-                "bb := 'temp';" +
-                "RETURN ; " +
-                "END " +
-                " $BODY$ " +
-                " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
+        final String hstore_array_type_sproc =
+            "CREATE OR REPLACE FUNCTION tmp.hstore_array_type_function(OUT aa tmp.hstore_array_type, OUT bb text) "
+                + "RETURNS record AS " + "$BODY$ " + "DECLARE " + "BEGIN "
+                + "aa := CAST ( ROW( ARRAY[ hstore('key','val') ], 'str') AS tmp.hstore_array_type); " + "bb := 'temp';"
+                + "RETURN ; " + "END " + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
 
         execute(hstore_array_type_sproc);
 
-        
-        /*
+        final String simple_with_enumeration_type_function =
+            "CREATE OR REPLACE FUNCTION tmp.simple_with_enumeration_type_function(OUT aa tmp.simple_with_enumeration_type) "
+                + "RETURNS tmp.simple_with_enumeration_type AS " + "$BODY$ " + "DECLARE " + "BEGIN "
+                + "aa := CAST ( ROW( 'VALUE_1'::tmp.enumeration, 'VALUE_2'::tmp.enumeration, 'str') AS tmp.simple_with_enumeration_type); "
+                + "RETURN ; " + "END " + " $BODY$ " + " LANGUAGE 'plpgsql' VOLATILE SECURITY DEFINER ";
 
-        execute("DROP SCHEMA IF EXISTS tmp CASCADE;");
-        execute("CREATE SCHEMA tmp;");
-        execute("CREATE TYPE tmp.simple_type AS (i int, l int, c varchar);");
+        execute(simple_with_enumeration_type_function);
+
+        /*
+         *
+         * execute("DROP SCHEMA IF EXISTS tmp CASCADE;");
+         * execute("CREATE SCHEMA tmp;");
+         * execute("CREATE TYPE tmp.simple_type AS (i int, l int, c varchar);");
          */
 
     }
@@ -169,6 +133,5 @@ public class AbstractTest {
         execute("DROP SCHEMA IF EXISTS tmp CASCADE;");
         execute("DROP SCHEMA IF EXISTS tmp2 CASCADE;");
     }
-
 
 }

--- a/src/test/java/com/typemapper/namedresult/CollectionTest.java
+++ b/src/test/java/com/typemapper/namedresult/CollectionTest.java
@@ -2,6 +2,7 @@ package com.typemapper.namedresult;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,193 +10,256 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
+
+import com.typemapper.namedresult.results.ClassWithEnum;
 import com.typemapper.namedresult.results.ClassWithList;
 import com.typemapper.namedresult.results.ClassWithObjectWithArray;
 import com.typemapper.namedresult.results.ClassWithPrimitives;
 import com.typemapper.namedresult.results.ClassWithSet;
+import com.typemapper.namedresult.results.ClassWithSetOfClassWithEnum;
+import com.typemapper.namedresult.results.ClassWithSetOfEnums;
 import com.typemapper.namedresult.results.ClassWithStringSet;
+import com.typemapper.namedresult.results.Enumeration;
 import com.typemapper.namedresult.results.ObjectWithArray;
 
 public class CollectionTest extends AbstractTest {
 
-	
-	@Test
-	public void testSimpleList() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ARRAY[ROW(1,2,'c')::tmp.simple_type, ROW(1,2,'c')::tmp.simple_type]::tmp.simple_type[] as arr");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithList.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithList result = (ClassWithList) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getArray());
-			Assert.assertTrue(result.getArray().size() == 2);
-			Assert.assertNotNull(result.getArray().get(0));
-			Assert.assertNotNull(result.getArray().get(1));
-			ClassWithPrimitives classWithPrimitives = result.getArray().get(0);
-			Assert.assertEquals(1, classWithPrimitives.getI());
-			Assert.assertEquals(2, classWithPrimitives.getL());
-			Assert.assertEquals('c', classWithPrimitives.getC());
-			classWithPrimitives = result.getArray().get(1);
-			Assert.assertEquals(1, classWithPrimitives.getI());
-			Assert.assertEquals(2, classWithPrimitives.getL());
-			Assert.assertEquals('c', classWithPrimitives.getC());
+    @Test
+    public void testSimpleList() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY[ROW(1,2,'c')::tmp.simple_type, ROW(1,2,'c')::tmp.simple_type]::tmp.simple_type[] as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithList.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithList result = (ClassWithList) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getArray());
+            Assert.assertTrue(result.getArray().size() == 2);
+            Assert.assertNotNull(result.getArray().get(0));
+            Assert.assertNotNull(result.getArray().get(1));
 
-		}
-	}
-	
-	@Test
-	public void testSimpleSet() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ARRAY[ROW(1,2,'c')::tmp.simple_type, ROW(1,2,'c')::tmp.simple_type]::tmp.simple_type[] as arr");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithSet.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithSet result = (ClassWithSet) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getArray());
-			Assert.assertTrue(result.getArray().size() == 2);
-			List<ClassWithPrimitives> list = new ArrayList<ClassWithPrimitives>();
-			for (ClassWithPrimitives tmp : result.getArray()) {
-				list.add(tmp);
-			}
-			Assert.assertNotNull(list.get(0));
-			Assert.assertNotNull(list.get(1));
-			ClassWithPrimitives classWithPrimitives = list.get(0);
-			Assert.assertEquals(1, classWithPrimitives.getI());
-			Assert.assertEquals(2, classWithPrimitives.getL());
-			Assert.assertEquals('c', classWithPrimitives.getC());
-			classWithPrimitives = list.get(1);
-			Assert.assertEquals(1, classWithPrimitives.getI());
-			Assert.assertEquals(2, classWithPrimitives.getL());
-			Assert.assertEquals('c', classWithPrimitives.getC());
+            ClassWithPrimitives classWithPrimitives = result.getArray().get(0);
+            Assert.assertEquals(1, classWithPrimitives.getI());
+            Assert.assertEquals(2, classWithPrimitives.getL());
+            Assert.assertEquals('c', classWithPrimitives.getC());
+            classWithPrimitives = result.getArray().get(1);
+            Assert.assertEquals(1, classWithPrimitives.getI());
+            Assert.assertEquals(2, classWithPrimitives.getL());
+            Assert.assertEquals('c', classWithPrimitives.getC());
 
-		}
-	}
-	
-	@Test
-	public void testSimpleStringSet() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ARRAY['result_1', 'result_2']::text[] as arr");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithStringSet.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithStringSet result = (ClassWithStringSet) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getArray());
-			Assert.assertTrue(result.getArray().size() == 2);
-			Assert.assertTrue(result.getArray().contains("result_1"));
-			Assert.assertTrue(result.getArray().contains("result_2"));
-		}
-	}
-	
-	@Test
-	public void testSimpleStringSetWithNullValue() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, null as arr");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithStringSet.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithStringSet result = (ClassWithStringSet) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNull(result.getArray());
-		}
-	}
-	
-	
-	@Test
-	public void testSimpleSetWithNullValue() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, null as arr");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithSet.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithSet result = (ClassWithSet) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNull(result.getArray());
-		}
-	}
-		
-	@Test
-	public void testObjectWithList() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT ROW(ARRAY[ROW(1,2,'c')::tmp.simple_type, ROW(1,2,'c')::tmp.simple_type], 'str')::tmp.array_type as obj, 'str' as str ");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithArray.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithArray result = (ClassWithObjectWithArray) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getObj());
-			Assert.assertEquals("str", result.getObj().getStr());
-			Assert.assertNotNull(result.getObj().getArray());
-			Assert.assertEquals(2, result.getObj().getArray().size());
-			
-			Assert.assertNotNull(result.getObj().getArray().get(0));
-			Assert.assertNotNull(result.getObj().getArray().get(1));
-			ClassWithPrimitives classWithPrimitives = result.getObj().getArray().get(0);
-			Assert.assertEquals(1, classWithPrimitives.getI());
-			Assert.assertEquals(2, classWithPrimitives.getL());
-			Assert.assertEquals('c', classWithPrimitives.getC());
-			classWithPrimitives = result.getObj().getArray().get(1);
-			Assert.assertEquals(1, classWithPrimitives.getI());
-			Assert.assertEquals(2, classWithPrimitives.getL());
-			Assert.assertEquals('c', classWithPrimitives.getC());
-		}
-	}
-	
-	@Test
-	public void testObjectWithEmptyList() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT ROW(ARRAY[]::tmp.simple_type[], 'str')::tmp.array_type as obj, 'str' as str ");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithArray.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithArray result = (ClassWithObjectWithArray) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getObj());
-			Assert.assertEquals("str", result.getObj().getStr());
-			Assert.assertNotNull(result.getObj().getArray());
-			Assert.assertEquals(0, result.getObj().getArray().size());}
-	}
-	
-	@Test
-	public void testObjectWithNullList() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT null as arr, 'str' as str ");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ObjectWithArray.class);
-		int i = 0;
-		while( rs.next() ) {
-			ObjectWithArray result = (ObjectWithArray) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNull(result.getArray());
-		}
-	}
-	
-	@Test
-	public void testObjectWithObjectNullList() throws Exception {
-		final PreparedStatement ps = connection.prepareStatement("SELECT ROW(null, 'str')::tmp.array_type as obj, 'str' as str ");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithArray.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithArray result = (ClassWithObjectWithArray) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getObj());
-			Assert.assertEquals("str", result.getObj().getStr());
-			Assert.assertNotNull(result.getObj().getArray());
-			Assert.assertEquals(0, result.getObj().getArray().size());
-		}
-	}
-	
+        }
+    }
+
+    @Test
+    public void testSimpleSet() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY[ROW(1,2,'c')::tmp.simple_type, ROW(1,2,'c')::tmp.simple_type]::tmp.simple_type[] as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithSet.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithSet result = (ClassWithSet) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getArray());
+            Assert.assertTrue(result.getArray().size() == 2);
+
+            final List<ClassWithPrimitives> list = new ArrayList<ClassWithPrimitives>();
+            for (final ClassWithPrimitives tmp : result.getArray()) {
+                list.add(tmp);
+            }
+
+            Assert.assertNotNull(list.get(0));
+            Assert.assertNotNull(list.get(1));
+
+            ClassWithPrimitives classWithPrimitives = list.get(0);
+            Assert.assertEquals(1, classWithPrimitives.getI());
+            Assert.assertEquals(2, classWithPrimitives.getL());
+            Assert.assertEquals('c', classWithPrimitives.getC());
+            classWithPrimitives = list.get(1);
+            Assert.assertEquals(1, classWithPrimitives.getI());
+            Assert.assertEquals(2, classWithPrimitives.getL());
+            Assert.assertEquals('c', classWithPrimitives.getC());
+
+        }
+    }
+
+    @Test
+    public void testSetWithEnums() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "select 'str' as str, ARRAY['VALUE_1'::tmp.enumeration, 'VALUE_2'::tmp.enumeration]::tmp.enumeration[] as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithSetOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithSetOfEnums result = (ClassWithSetOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getArray());
+            Assert.assertTrue(result.getArray().size() == 2);
+
+            Assert.assertTrue(result.getArray().contains(Enumeration.VALUE_1));
+            Assert.assertTrue(result.getArray().contains(Enumeration.VALUE_2));
+        }
+    }
+
+    @Test
+    public void testClassWithSetOfClassWithEnum() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "select 'str' as str, ARRAY[ROW('VALUE_1'::tmp.enumeration, 'VALUE_2'::tmp.enumeration)::tmp.simple_enumeration_type, ROW('VALUE_1'::tmp.enumeration, 'VALUE_2'::tmp.enumeration)::tmp.simple_enumeration_type]::tmp.simple_enumeration_type[] as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithSetOfClassWithEnum.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithSetOfClassWithEnum result = (ClassWithSetOfClassWithEnum) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getArray());
+            Assert.assertTrue(result.getArray().size() == 2);
+
+            final List<ClassWithEnum> list = new ArrayList<ClassWithEnum>();
+            for (final ClassWithEnum tmp : result.getArray()) {
+                list.add(tmp);
+            }
+
+            Assert.assertNotNull(list.get(0));
+            Assert.assertNotNull(list.get(1));
+
+            final ClassWithEnum classWithEnum = list.get(0);
+            Assert.assertEquals(Enumeration.VALUE_1, classWithEnum.getValue1());
+            Assert.assertEquals(Enumeration.VALUE_2, classWithEnum.getValue2());
+        }
+    }
+
+    @Test
+    public void testSimpleStringSet() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY['result_1', 'result_2']::text[] as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithStringSet.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithStringSet result = (ClassWithStringSet) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getArray());
+            Assert.assertTrue(result.getArray().size() == 2);
+            Assert.assertTrue(result.getArray().contains("result_1"));
+            Assert.assertTrue(result.getArray().contains("result_2"));
+        }
+    }
+
+    @Test
+    public void testSimpleStringSetWithNullValue() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, null as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithStringSet.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithStringSet result = (ClassWithStringSet) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNull(result.getArray());
+        }
+    }
+
+    @Test
+    public void testSimpleSetWithNullValue() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, null as arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithSet.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithSet result = (ClassWithSet) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNull(result.getArray());
+        }
+    }
+
+    @Test
+    public void testObjectWithList() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT ROW(ARRAY[ROW(1,2,'c')::tmp.simple_type, ROW(1,2,'c')::tmp.simple_type], 'str')::tmp.array_type as obj, 'str' as str ");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithArray.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithArray result = (ClassWithObjectWithArray) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getObj());
+            Assert.assertEquals("str", result.getObj().getStr());
+            Assert.assertNotNull(result.getObj().getArray());
+            Assert.assertEquals(2, result.getObj().getArray().size());
+
+            Assert.assertNotNull(result.getObj().getArray().get(0));
+            Assert.assertNotNull(result.getObj().getArray().get(1));
+
+            ClassWithPrimitives classWithPrimitives = result.getObj().getArray().get(0);
+            Assert.assertEquals(1, classWithPrimitives.getI());
+            Assert.assertEquals(2, classWithPrimitives.getL());
+            Assert.assertEquals('c', classWithPrimitives.getC());
+            classWithPrimitives = result.getObj().getArray().get(1);
+            Assert.assertEquals(1, classWithPrimitives.getI());
+            Assert.assertEquals(2, classWithPrimitives.getL());
+            Assert.assertEquals('c', classWithPrimitives.getC());
+        }
+    }
+
+    @Test
+    public void testObjectWithEmptyList() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT ROW(ARRAY[]::tmp.simple_type[], 'str')::tmp.array_type as obj, 'str' as str ");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithArray.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithArray result = (ClassWithObjectWithArray) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getObj());
+            Assert.assertEquals("str", result.getObj().getStr());
+            Assert.assertNotNull(result.getObj().getArray());
+            Assert.assertEquals(0, result.getObj().getArray().size());
+        }
+    }
+
+    @Test
+    public void testObjectWithNullList() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement("SELECT null as arr, 'str' as str ");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ObjectWithArray.class);
+        int i = 0;
+        while (rs.next()) {
+            final ObjectWithArray result = (ObjectWithArray) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNull(result.getArray());
+        }
+    }
+
+    @Test
+    public void testObjectWithObjectNullList() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT ROW(null, 'str')::tmp.array_type as obj, 'str' as str ");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithArray.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithArray result = (ClassWithObjectWithArray) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getObj());
+            Assert.assertEquals("str", result.getObj().getStr());
+            Assert.assertNotNull(result.getObj().getArray());
+            Assert.assertEquals(0, result.getObj().getArray().size());
+        }
+    }
+
 }

--- a/src/test/java/com/typemapper/namedresult/CollectionWithEnumsTest.java
+++ b/src/test/java/com/typemapper/namedresult/CollectionWithEnumsTest.java
@@ -1,0 +1,146 @@
+package com.typemapper.namedresult;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.postgresql.util.PSQLException;
+
+import com.typemapper.AbstractTest;
+
+import com.typemapper.core.TypeMapper;
+import com.typemapper.core.TypeMapperFactory;
+
+import com.typemapper.namedresult.results.ClassWithListOfEnums;
+import com.typemapper.namedresult.results.Enumeration;
+
+public class CollectionWithEnumsTest extends AbstractTest {
+
+    @Test
+    public void testListWithEnums() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY['VALUE_1'::enumeration, 'VALUE_2'::enumeration]::enumeration[] as enum_arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<ClassWithListOfEnums> mapper = TypeMapperFactory.createTypeMapper(ClassWithListOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithListOfEnums result = (ClassWithListOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertNotNull(result.getEnumList());
+            Assert.assertTrue(result.getEnumList().size() == 2);
+            Assert.assertNotNull(result.getEnumList().get(0));
+            Assert.assertNotNull(result.getEnumList().get(1));
+
+            final Enumeration enum1 = result.getEnumList().get(0);
+            Assert.assertEquals(Enumeration.VALUE_1, enum1);
+
+            final Enumeration enum2 = result.getEnumList().get(1);
+            Assert.assertEquals(Enumeration.VALUE_2, enum2);
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testListWithEmptyEnums() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY[]::enumeration[] as enum_arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<ClassWithListOfEnums> mapper = TypeMapperFactory.createTypeMapper(ClassWithListOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithListOfEnums result = (ClassWithListOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertNotNull(result.getEnumList());
+            Assert.assertTrue(result.getEnumList().size() == 0);
+        }
+    }
+
+    @Test
+    public void testListWithEmptyEnumOrdinals() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ARRAY[0, 1] as enum_arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<ClassWithListOfEnums> mapper = TypeMapperFactory.createTypeMapper(ClassWithListOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithListOfEnums result = (ClassWithListOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertNotNull(result.getEnumList());
+            Assert.assertTrue(result.getEnumList().size() == 2);
+            Assert.assertNotNull(result.getEnumList().get(0));
+            Assert.assertNotNull(result.getEnumList().get(1));
+
+            final Enumeration enum1 = result.getEnumList().get(0);
+            Assert.assertEquals(Enumeration.VALUE_1, enum1);
+
+            final Enumeration enum2 = result.getEnumList().get(1);
+            Assert.assertEquals(Enumeration.VALUE_2, enum2);
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testListWithNullEnum() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY[NULL::enumeration, 'VALUE_2'::enumeration]::enumeration[] as enum_arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<ClassWithListOfEnums> mapper = TypeMapperFactory.createTypeMapper(ClassWithListOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithListOfEnums result = (ClassWithListOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertNotNull(result.getEnumList());
+            Assert.assertTrue(result.getEnumList().size() == 2);
+            Assert.assertNull(result.getEnumList().get(0));
+            Assert.assertNotNull(result.getEnumList().get(1));
+
+            final Enumeration enum2 = result.getEnumList().get(1);
+            Assert.assertEquals(Enumeration.VALUE_2, enum2);
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testListWithNullEnum2() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY[NULL, 'VALUE_2'::enumeration] as enum_arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<ClassWithListOfEnums> mapper = TypeMapperFactory.createTypeMapper(ClassWithListOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithListOfEnums result = (ClassWithListOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertNotNull(result.getEnumList());
+            Assert.assertTrue(result.getEnumList().size() == 2);
+            Assert.assertNull(result.getEnumList().get(0));
+            Assert.assertNotNull(result.getEnumList().get(1));
+
+            final Enumeration enum2 = result.getEnumList().get(1);
+            Assert.assertEquals(Enumeration.VALUE_2, enum2);
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testListWithNullEnum3() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ARRAY[NULL] as enum_arr");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<ClassWithListOfEnums> mapper = TypeMapperFactory.createTypeMapper(ClassWithListOfEnums.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithListOfEnums result = (ClassWithListOfEnums) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertNotNull(result.getEnumList());
+            Assert.assertTrue(result.getEnumList().size() == 1);
+            Assert.assertNull(result.getEnumList().get(0));
+        }
+    }
+
+    @Test(expected = PSQLException.class)
+    public void testListWithInvalidEnums() throws Exception {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ARRAY['VALUE_3'::enumeration]::enumeration[] as enum_arr");
+        ps.executeQuery();
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/EnumTest.java
+++ b/src/test/java/com/typemapper/namedresult/EnumTest.java
@@ -8,25 +8,57 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
+
+import com.typemapper.namedresult.results.ClassWithEmbedEnumClass;
 import com.typemapper.namedresult.results.ClassWithEnum;
 import com.typemapper.namedresult.results.Enumeration;
 
 public class EnumTest extends AbstractTest {
-	
-	@Test
-	public void testEnumMappings() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 0 as a, 'VALUE_2' as b");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithEnum.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithEnum result = (ClassWithEnum) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals(Enumeration.VALUE_1, result.getValue1());
-			Assert.assertEquals(Enumeration.VALUE_2, result.getValue2());
-		}
-	}	
 
+    @Test
+    public void testEnumMappings() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 0 as a, 'VALUE_2' as b");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEnum.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEnum result = (ClassWithEnum) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals(Enumeration.VALUE_1, result.getValue1());
+            Assert.assertEquals(Enumeration.VALUE_2, result.getValue2());
+        }
+    }
+
+    @Test
+    public void testEnumMappingsWithEnumType() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 0 as a, 'VALUE_2'::enumeration as b;");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEnum.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEnum result = (ClassWithEnum) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals(Enumeration.VALUE_1, result.getValue1());
+            Assert.assertEquals(Enumeration.VALUE_2, result.getValue2());
+        }
+    }
+
+    @Test
+    public void testEnumMappingsWithEnumInComplexType() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement(
+                "select * from simple_with_enumeration_type_function();");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbedEnumClass.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEmbedEnumClass result = (ClassWithEmbedEnumClass) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertEquals(Enumeration.VALUE_1, result.getEmbeddedEnum().getValue1());
+            Assert.assertEquals(Enumeration.VALUE_2, result.getEmbeddedEnum().getValue2());
+        }
+    }
 }

--- a/src/test/java/com/typemapper/namedresult/HStoreTest.java
+++ b/src/test/java/com/typemapper/namedresult/HStoreTest.java
@@ -3,52 +3,54 @@ package com.typemapper.namedresult;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
 import java.util.List;
 import java.util.Map;
 
-import com.typemapper.namedresult.results.ClassWithClassWithMap;
-import com.typemapper.namedresult.results.ClassWithClassWithListOfMap;
-import com.typemapper.namedresult.results.ClassWithListOfMap;
 import org.junit.Assert;
 import org.junit.Test;
+
+import org.springframework.util.CollectionUtils;
 
 import com.typemapper.AbstractTest;
 
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
 
+import com.typemapper.namedresult.results.ClassWithClassWithListOfMap;
+import com.typemapper.namedresult.results.ClassWithClassWithMap;
+import com.typemapper.namedresult.results.ClassWithListOfMap;
 import com.typemapper.namedresult.results.ClassWithMap;
-import org.springframework.util.CollectionUtils;
 
 public class HStoreTest extends AbstractTest {
 
     @Test
-    //@Ignore("Needs hstore() installed into postgres DB")
+    // @Ignore("Needs hstore() installed into postgres DB")
     public void testHStoreNull() throws SQLException {
         TypeMapperFactory.initTypeAndFunctionCaches(connection, "default");
 
         final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, null as map");
         final ResultSet rs = ps.executeQuery();
-        final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithMap.class);
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithMap.class);
         int i = 0;
         while (rs.next()) {
-            ClassWithMap result = (ClassWithMap) mapper.mapRow(rs, i++);
+            final ClassWithMap result = (ClassWithMap) mapper.mapRow(rs, i++);
             Assert.assertEquals("str", result.getStr());
             Assert.assertNull(result.getMap());
         }
     }
-    
+
     @Test
-    //@Ignore("Needs hstore() installed into postgres DB")
+    // @Ignore("Needs hstore() installed into postgres DB")
     public void testHStoreFilled() throws SQLException {
         TypeMapperFactory.initTypeAndFunctionCaches(connection, "default");
 
         final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, hstore('key', 'val') as map");
         final ResultSet rs = ps.executeQuery();
-        final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithMap.class);
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithMap.class);
         int i = 0;
         while (rs.next()) {
-            ClassWithMap result = (ClassWithMap) mapper.mapRow(rs, i++);
+            final ClassWithMap result = (ClassWithMap) mapper.mapRow(rs, i++);
             Assert.assertEquals("str", result.getStr());
             Assert.assertNotNull(result.getMap());
             Assert.assertEquals("key", result.getMap().keySet().iterator().next());
@@ -56,18 +58,17 @@ public class HStoreTest extends AbstractTest {
         }
     }
 
-
     @Test
-    //@Ignore("Needs hstore() installed into postgres DB")
+    // @Ignore("Needs hstore() installed into postgres DB")
     public void testHStoreType() throws SQLException {
         TypeMapperFactory.initTypeAndFunctionCaches(connection, "default");
 
         final PreparedStatement ps = connection.prepareStatement("SELECT tmp.hstore_type_function();");
         final ResultSet rs = ps.executeQuery();
-        final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithClassWithMap.class);
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithClassWithMap.class);
         int i = 0;
         while (rs.next()) {
-            ClassWithClassWithMap firstResult = (ClassWithClassWithMap) mapper.mapRow(rs, i++);
+            final ClassWithClassWithMap firstResult = (ClassWithClassWithMap) mapper.mapRow(rs, i++);
             final ClassWithMap result = firstResult.getClassWithMap();
             Assert.assertEquals("str", result.getStr());
             Assert.assertNotNull(result.getMap());
@@ -76,29 +77,26 @@ public class HStoreTest extends AbstractTest {
         }
     }
 
-
     @Test
-    //@Ignore("Needs hstore() installed into postgres DB")
+    // @Ignore("Needs hstore() installed into postgres DB")
     public void testHStoreArrayType() throws SQLException {
         TypeMapperFactory.initTypeAndFunctionCaches(connection, "default");
 
         final PreparedStatement ps = connection.prepareStatement("SELECT tmp.hstore_array_type_function();");
         final ResultSet rs = ps.executeQuery();
-        final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithClassWithListOfMap.class);
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithClassWithListOfMap.class);
         int i = 0;
         while (rs.next()) {
-            ClassWithClassWithListOfMap firstResult = (ClassWithClassWithListOfMap) mapper.mapRow(rs, i++);
+            final ClassWithClassWithListOfMap firstResult = (ClassWithClassWithListOfMap) mapper.mapRow(rs, i++);
             final ClassWithListOfMap result = firstResult.getClassWithListOfMap();
-            final List<Map<String,String>> mapList = result.getMapList();
-            Assert.assertNotNull("List is Null",mapList);
-            Assert.assertFalse("List is Empty",CollectionUtils.isEmpty(mapList));
+            final List<Map<String, String>> mapList = result.getMapList();
+            Assert.assertNotNull("List is Null", mapList);
+            Assert.assertFalse("List is Empty", CollectionUtils.isEmpty(mapList));
             Assert.assertEquals("str", result.getStr());
             Assert.assertNotNull(result.getMapList().get(0));
             Assert.assertEquals("key", result.getMapList().get(0).keySet().iterator().next());
             Assert.assertEquals("val", result.getMapList().get(0).values().iterator().next());
         }
     }
-
-
 
 }

--- a/src/test/java/com/typemapper/namedresult/InheritanceTest.java
+++ b/src/test/java/com/typemapper/namedresult/InheritanceTest.java
@@ -8,25 +8,27 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
+
 import com.typemapper.namedresult.results.ChildClassWithPrimitives;
 
 public class InheritanceTest extends AbstractTest {
-	
-	@Test
-	public void testPrimitiveMappings() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ChildClassWithPrimitives.class);
-		int i = 0;
-		while( rs.next() ) {
-			ChildClassWithPrimitives result = (ChildClassWithPrimitives) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals(1, result.getI());
-			Assert.assertEquals(2, result.getL());
-			Assert.assertEquals('c', result.getC());
-		}
-	}
+
+    @Test
+    public void testPrimitiveMappings() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ChildClassWithPrimitives.class);
+        int i = 0;
+        while (rs.next()) {
+            final ChildClassWithPrimitives result = (ChildClassWithPrimitives) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals(1, result.getI());
+            Assert.assertEquals(2, result.getL());
+            Assert.assertEquals('c', result.getC());
+        }
+    }
 
 }

--- a/src/test/java/com/typemapper/namedresult/ObjectTest.java
+++ b/src/test/java/com/typemapper/namedresult/ObjectTest.java
@@ -8,112 +8,122 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
+
 import com.typemapper.namedresult.results.ClassWithObject;
 import com.typemapper.namedresult.results.ClassWithObjectWithEmbed;
 import com.typemapper.namedresult.results.ClassWithObjectWithObject;
 
-
 public class ObjectTest extends AbstractTest {
 
-	@Test
-	public void testPrimitiveMappings() throws SQLException {
-		TypeMapperFactory.initTypeAndFunctionCaches(connection, "default");
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ROW(1,2,'c')::tmp.simple_type as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObject.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObject result = (ClassWithObject) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result.getPrimitives());
-			Assert.assertEquals(1, result.getPrimitives().getI());
-			Assert.assertEquals(2, result.getPrimitives().getL());
-			Assert.assertEquals('c', result.getPrimitives().getC());
-			Assert.assertEquals("str", result.getStr());
-		}
-	}
-	
-	@Test
-	public void testPrimitiveMappingsWithEmbeds() throws SQLException {
-		//SELECT 1 as i, 2 as l, 'c' as c, 'str' as str
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ROW(1,2,'c','str')::tmp.simple_type_for_embed as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithEmbed.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithEmbed result = (ClassWithObjectWithEmbed) mapper.mapRow(rs, i++);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getClassWithEmbed());
-			Assert.assertEquals("str", result.getClassWithEmbed().getStr());
-			Assert.assertEquals(1, result.getClassWithEmbed().getPrimitives().getI());
-			Assert.assertEquals(2, result.getClassWithEmbed().getPrimitives().getL());
-			Assert.assertEquals('c', result.getClassWithEmbed().getPrimitives().getC());
-		}
-	}
-	
-	@Test
-	public void testObjectInObject() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ROW(ROW(1,2,'c')::tmp.simple_type,'str')::tmp.complex_type as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithObject.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithObject result = (ClassWithObjectWithObject) mapper.mapRow(rs, i++);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getWithObj());
-			Assert.assertEquals("str", result.getWithObj().getStr());
-			Assert.assertNotNull("str", result.getWithObj().getPrimitives());
-			Assert.assertEquals('c', result.getWithObj().getPrimitives().getC());
-			Assert.assertEquals(2, result.getWithObj().getPrimitives().getL());
-			Assert.assertEquals(1, result.getWithObj().getPrimitives().getI());
-		}
-		
-	}
+    @Test
+    public void testPrimitiveMappings() throws SQLException {
+        TypeMapperFactory.initTypeAndFunctionCaches(connection, "default");
 
-	@Test
-	public void testNullObjectInObject() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ROW(null,'str')::tmp.complex_type as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithObject.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithObject result = (ClassWithObjectWithObject) mapper.mapRow(rs, i++);
-			Assert.assertEquals("str", result.getStr());
-			Assert.assertNotNull(result.getWithObj());
-			Assert.assertEquals("str", result.getWithObj().getStr());
-			Assert.assertNull(result.getWithObj().getPrimitives());
-		}
-		
-	}
-	
-	@Test
-	public void testObjectStringMappingWithNullString() throws SQLException {
-		//SELECT 1 as i, 2 as l, 'c' as c, 'str' as str
-		final PreparedStatement ps = connection.prepareStatement("SELECT ROW(1,2,'c', null)::tmp.simple_type_for_embed as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithEmbed.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithEmbed result = (ClassWithObjectWithEmbed) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result.getClassWithEmbed());
-			Assert.assertNull(result.getClassWithEmbed().getStr());
-		}
-	}
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ROW(1,2,'c')::tmp.simple_type as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObject.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObject result = (ClassWithObject) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result.getPrimitives());
+            Assert.assertEquals(1, result.getPrimitives().getI());
+            Assert.assertEquals(2, result.getPrimitives().getL());
+            Assert.assertEquals('c', result.getPrimitives().getC());
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
 
-	@Test
-	public void testObjectStringMappingWithEmptyString() throws SQLException {
-		//SELECT 1 as i, 2 as l, 'c' as c, 'str' as str
-		final PreparedStatement ps = connection.prepareStatement("SELECT  ROW(1,2,'c','')::tmp.simple_type_for_embed as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithEmbed.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObjectWithEmbed result = (ClassWithObjectWithEmbed) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result.getClassWithEmbed());
-			Assert.assertEquals("", result.getClassWithEmbed().getStr());
-		}
-	}
+    @Test
+    public void testPrimitiveMappingsWithEmbeds() throws SQLException {
 
+        // SELECT 1 as i, 2 as l, 'c' as c, 'str' as str
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ROW(1,2,'c','str')::tmp.simple_type_for_embed as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithEmbed.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithEmbed result = (ClassWithObjectWithEmbed) mapper.mapRow(rs, i++);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getClassWithEmbed());
+            Assert.assertEquals("str", result.getClassWithEmbed().getStr());
+            Assert.assertEquals(1, result.getClassWithEmbed().getPrimitives().getI());
+            Assert.assertEquals(2, result.getClassWithEmbed().getPrimitives().getL());
+            Assert.assertEquals('c', result.getClassWithEmbed().getPrimitives().getC());
+        }
+    }
+
+    @Test
+    public void testObjectInObject() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ROW(ROW(1,2,'c')::tmp.simple_type,'str')::tmp.complex_type as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithObject.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithObject result = (ClassWithObjectWithObject) mapper.mapRow(rs, i++);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getWithObj());
+            Assert.assertEquals("str", result.getWithObj().getStr());
+            Assert.assertNotNull("str", result.getWithObj().getPrimitives());
+            Assert.assertEquals('c', result.getWithObj().getPrimitives().getC());
+            Assert.assertEquals(2, result.getWithObj().getPrimitives().getL());
+            Assert.assertEquals(1, result.getWithObj().getPrimitives().getI());
+        }
+
+    }
+
+    @Test
+    public void testNullObjectInObject() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ROW(null,'str')::tmp.complex_type as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithObject.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithObject result = (ClassWithObjectWithObject) mapper.mapRow(rs, i++);
+            Assert.assertEquals("str", result.getStr());
+            Assert.assertNotNull(result.getWithObj());
+            Assert.assertEquals("str", result.getWithObj().getStr());
+            Assert.assertNull(result.getWithObj().getPrimitives());
+        }
+
+    }
+
+    @Test
+    public void testObjectStringMappingWithNullString() throws SQLException {
+
+        // SELECT 1 as i, 2 as l, 'c' as c, 'str' as str
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT ROW(1,2,'c', null)::tmp.simple_type_for_embed as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithEmbed.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithEmbed result = (ClassWithObjectWithEmbed) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result.getClassWithEmbed());
+            Assert.assertNull(result.getClassWithEmbed().getStr());
+        }
+    }
+
+    @Test
+    public void testObjectStringMappingWithEmptyString() throws SQLException {
+
+        // SELECT 1 as i, 2 as l, 'c' as c, 'str' as str
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT  ROW(1,2,'c','')::tmp.simple_type_for_embed as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObjectWithEmbed.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObjectWithEmbed result = (ClassWithObjectWithEmbed) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result.getClassWithEmbed());
+            Assert.assertEquals("", result.getClassWithEmbed().getStr());
+        }
+    }
 
 }

--- a/src/test/java/com/typemapper/namedresult/PrimitiveTest.java
+++ b/src/test/java/com/typemapper/namedresult/PrimitiveTest.java
@@ -1,6 +1,7 @@
 package com.typemapper.namedresult;
 
 import java.math.BigDecimal;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -9,114 +10,147 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
+
 import com.typemapper.namedresult.results.ClassWithBadPrimitives;
 import com.typemapper.namedresult.results.ClassWithBigDecimal;
 import com.typemapper.namedresult.results.ClassWithEmbed;
+import com.typemapper.namedresult.results.ClassWithEmbedEnumClass;
 import com.typemapper.namedresult.results.ClassWithPrimitives;
+import com.typemapper.namedresult.results.Enumeration;
 
 public class PrimitiveTest extends AbstractTest {
 
-	
-	@Test
-	public void testPrimitiveMappings() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithPrimitives.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithPrimitives result = (ClassWithPrimitives) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals(1, result.getI());
-			Assert.assertEquals(2, result.getL());
-			Assert.assertEquals('c', result.getC());
-		}
-	}
-	
-	@Test
-	public void testPrimitiveNotMappedFieldsMappings() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 1 as j, 2 as l, 'c' as c");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithPrimitives.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithPrimitives result = (ClassWithPrimitives) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals(0, result.getI());
-			Assert.assertEquals(2, result.getL());
-			Assert.assertEquals('c', result.getC());
-		}
-	}
-	
-	@Test
-	public void testPrimitiveBadMappedMappings() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithBadPrimitives.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithBadPrimitives result = (ClassWithBadPrimitives) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result);
-			Assert.assertEquals(0, result.getI());
-			Assert.assertEquals(2, result.getL());
-			Assert.assertEquals('c', result.getC());
-		}
-	}	
-	
-	
-	@Test
-	public void testPrimitiveMappingsWithEmbed() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c, 'str' as str");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbed.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithEmbed result = (ClassWithEmbed) mapper.mapRow(rs, i++);
-			Assert.assertNotNull(result.getPrimitives());
-			Assert.assertEquals(1, result.getPrimitives().getI());
-			Assert.assertEquals(2, result.getPrimitives().getL());
-			Assert.assertEquals('c', result.getPrimitives().getC());
-			Assert.assertEquals("str", result.getStr());
-		}
-	}
-	
-	@Test
-	public void testPrimitiveBigDecimalMapper() throws SQLException {
-		final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithBigDecimal.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithBigDecimal result = (ClassWithBigDecimal) mapper.mapRow(rs, i++);
-			Assert.assertEquals(new BigDecimal(1), result.getI());
-		}
-	}		
-	
-	@Test
-	public void testNullString() throws Exception {
+    @Test
+    public void testPrimitiveMappings() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithPrimitives.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithPrimitives result = (ClassWithPrimitives) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals(1, result.getI());
+            Assert.assertEquals(2, result.getL());
+            Assert.assertEquals('c', result.getC());
+        }
+    }
 
-		final PreparedStatement ps = connection.prepareStatement("SELECT null as str");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbed.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithEmbed result = (ClassWithEmbed) mapper.mapRow(rs, i++);
-			Assert.assertNull(result.getStr());
-		}
-	}
-	
-	@Test
-	public void testEmptyString() throws Exception {
+    @Test
+    public void testPrimitiveNotMappedFieldsMappings() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 1 as j, 2 as l, 'c' as c");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithPrimitives.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithPrimitives result = (ClassWithPrimitives) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals(0, result.getI());
+            Assert.assertEquals(2, result.getL());
+            Assert.assertEquals('c', result.getC());
+        }
+    }
 
-		final PreparedStatement ps = connection.prepareStatement("SELECT '' as str");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbed.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithEmbed result = (ClassWithEmbed) mapper.mapRow(rs, i++);
-			Assert.assertEquals("", result.getStr());
-		}
-	}	
+    @Test
+    public void testPrimitiveBadMappedMappings() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithBadPrimitives.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithBadPrimitives result = (ClassWithBadPrimitives) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result);
+            Assert.assertEquals(0, result.getI());
+            Assert.assertEquals(2, result.getL());
+            Assert.assertEquals('c', result.getC());
+        }
+    }
+
+    @Test
+    public void testPrimitiveMappingsWithEmbed() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i, 2 as l, 'c' as c, 'str' as str");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbed.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEmbed result = (ClassWithEmbed) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result.getPrimitives());
+            Assert.assertEquals(1, result.getPrimitives().getI());
+            Assert.assertEquals(2, result.getPrimitives().getL());
+            Assert.assertEquals('c', result.getPrimitives().getC());
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testMappingsWithEmbedEnum() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 0 as a, 'VALUE_2' as b, 'str' as str");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbedEnumClass.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEmbedEnumClass result = (ClassWithEmbedEnumClass) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result.getEmbeddedEnum());
+            Assert.assertEquals(Enumeration.VALUE_1, result.getEmbeddedEnum().getValue1());
+            Assert.assertEquals(Enumeration.VALUE_2, result.getEmbeddedEnum().getValue2());
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testMappingsWithEmbedEnumAndEnumDBTypes() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'VALUE_1'::enumeration as a, 'VALUE_2'::enumeration as b, 'str' as str");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbedEnumClass.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEmbedEnumClass result = (ClassWithEmbedEnumClass) mapper.mapRow(rs, i++);
+            Assert.assertNotNull(result.getEmbeddedEnum());
+            Assert.assertEquals(Enumeration.VALUE_1, result.getEmbeddedEnum().getValue1());
+            Assert.assertEquals(Enumeration.VALUE_2, result.getEmbeddedEnum().getValue2());
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
+
+    @Test
+    public void testPrimitiveBigDecimalMapper() throws SQLException {
+        final PreparedStatement ps = connection.prepareStatement("SELECT 1 as i");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithBigDecimal.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithBigDecimal result = (ClassWithBigDecimal) mapper.mapRow(rs, i++);
+            Assert.assertEquals(new BigDecimal(1), result.getI());
+        }
+    }
+
+    @Test
+    public void testNullString() throws Exception {
+
+        final PreparedStatement ps = connection.prepareStatement("SELECT null as str");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbed.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEmbed result = (ClassWithEmbed) mapper.mapRow(rs, i++);
+            Assert.assertNull(result.getStr());
+        }
+    }
+
+    @Test
+    public void testEmptyString() throws Exception {
+
+        final PreparedStatement ps = connection.prepareStatement("SELECT '' as str");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithEmbed.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithEmbed result = (ClassWithEmbed) mapper.mapRow(rs, i++);
+            Assert.assertEquals("", result.getStr());
+        }
+    }
 
 }

--- a/src/test/java/com/typemapper/namedresult/SchemaResolvingTest.java
+++ b/src/test/java/com/typemapper/namedresult/SchemaResolvingTest.java
@@ -8,29 +8,33 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
 import com.typemapper.core.db.DbTypeRegister;
+
 import com.typemapper.namedresult.results.ClassWithObject2;
 
 public class SchemaResolvingTest extends AbstractTest {
-	
-	@Test
-	public void testPrimitiveMappings() throws SQLException {
-		connection.createStatement().execute("set search_path to tmp2,tmp");
-		DbTypeRegister.reInitRegister(connection);
-		final PreparedStatement ps = connection.prepareStatement("SELECT 'str' as str, ROW(1,2,'c','h')::tmp2.simple_type as obj");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ClassWithObject2.class);
-		int i = 0;
-		while( rs.next() ) {
-			ClassWithObject2 result = (ClassWithObject2) mapper.mapRow(rs, i++);
-			Assert.assertEquals(1, result.getPrimitives().getI());
-			Assert.assertEquals(2, result.getPrimitives().getL());
-			Assert.assertEquals('c', result.getPrimitives().getC());
-			Assert.assertEquals('h', result.getPrimitives().getH());
-			Assert.assertEquals("str", result.getStr());
-		}
-	}	
+
+    @Test
+    public void testPrimitiveMappings() throws SQLException {
+        connection.createStatement().execute("set search_path to tmp2,tmp");
+        DbTypeRegister.reInitRegister(connection);
+
+        final PreparedStatement ps = connection.prepareStatement(
+                "SELECT 'str' as str, ROW(1,2,'c','h')::tmp2.simple_type as obj");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ClassWithObject2.class);
+        int i = 0;
+        while (rs.next()) {
+            final ClassWithObject2 result = (ClassWithObject2) mapper.mapRow(rs, i++);
+            Assert.assertEquals(1, result.getPrimitives().getI());
+            Assert.assertEquals(2, result.getPrimitives().getL());
+            Assert.assertEquals('c', result.getPrimitives().getC());
+            Assert.assertEquals('h', result.getPrimitives().getH());
+            Assert.assertEquals("str", result.getStr());
+        }
+    }
 
 }

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithEmbedEnumClass.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithEmbedEnumClass.java
@@ -1,0 +1,30 @@
+package com.typemapper.namedresult.results;
+
+import com.typemapper.annotations.DatabaseField;
+import com.typemapper.annotations.Embed;
+
+public class ClassWithEmbedEnumClass {
+
+    @Embed
+    private ClassWithEnum embeddedEnum;
+
+    @DatabaseField(name = "str")
+    private String str;
+
+    public ClassWithEnum getEmbeddedEnum() {
+        return embeddedEnum;
+    }
+
+    public void setEmbeddedEnum(final ClassWithEnum embeddedEnum) {
+        this.embeddedEnum = embeddedEnum;
+    }
+
+    public String getStr() {
+        return str;
+    }
+
+    public void setStr(final String str) {
+        this.str = str;
+    }
+
+}

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithEnum.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithEnum.java
@@ -1,30 +1,38 @@
 package com.typemapper.namedresult.results;
 
 import com.typemapper.annotations.DatabaseField;
+import com.typemapper.annotations.DatabaseType;
 
+@DatabaseType(name = "simple_enumeration_type")
 public class ClassWithEnum {
-	
-	@DatabaseField(name="a")
-	Enumeration value1;
-	
-	@DatabaseField(name="b")
-	Enumeration value2;
 
-	public Enumeration getValue1() {
-		return value1;
-	}
+    @DatabaseField(name = "a")
+    Enumeration value1;
 
-	public void setValue1(Enumeration value1) {
-		this.value1 = value1;
-	}
+    @DatabaseField(name = "b")
+    Enumeration value2;
 
-	public Enumeration getValue2() {
-		return value2;
-	}
+    public ClassWithEnum() { }
 
-	public void setValue2(Enumeration value2) {
-		this.value2 = value2;
-	}
-	
+    public ClassWithEnum(final Enumeration value1, final Enumeration value2) {
+        this.value1 = value1;
+        this.value2 = value2;
+    }
+
+    public Enumeration getValue1() {
+        return value1;
+    }
+
+    public void setValue1(final Enumeration value1) {
+        this.value1 = value1;
+    }
+
+    public Enumeration getValue2() {
+        return value2;
+    }
+
+    public void setValue2(final Enumeration value2) {
+        this.value2 = value2;
+    }
 
 }

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithListOfEnums.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithListOfEnums.java
@@ -1,0 +1,33 @@
+package com.typemapper.namedresult.results;
+
+import java.util.List;
+
+import com.typemapper.annotations.DatabaseField;
+
+/**
+ * @author  Carsten Wolters <c.wolters@gmx.de>
+ */
+public class ClassWithListOfEnums {
+
+    @DatabaseField(name = "enum_arr")
+    private List<Enumeration> enumList;
+
+    @DatabaseField(name = "str")
+    private String str;
+
+    public List<Enumeration> getEnumList() {
+        return enumList;
+    }
+
+    public void setEnumList(final List<Enumeration> enumList) {
+        this.enumList = enumList;
+    }
+
+    public String getStr() {
+        return str;
+    }
+
+    public void setStr(final String str) {
+        this.str = str;
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithSetOfClassWithEnum.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithSetOfClassWithEnum.java
@@ -1,0 +1,31 @@
+package com.typemapper.namedresult.results;
+
+import java.util.Set;
+
+import com.typemapper.annotations.DatabaseField;
+
+public class ClassWithSetOfClassWithEnum {
+
+    @DatabaseField(name = "str")
+    private String str;
+
+    @DatabaseField(name = "arr")
+    private Set<ClassWithEnum> array;
+
+    public String getStr() {
+        return str;
+    }
+
+    public void setStr(final String str) {
+        this.str = str;
+    }
+
+    public Set<ClassWithEnum> getArray() {
+        return array;
+    }
+
+    public void setArray(final Set<ClassWithEnum> array) {
+        this.array = array;
+    }
+
+}

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithSetOfEnums.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithSetOfEnums.java
@@ -1,0 +1,30 @@
+package com.typemapper.namedresult.results;
+
+import java.util.Set;
+
+import com.typemapper.annotations.DatabaseField;
+
+public class ClassWithSetOfEnums {
+
+    @DatabaseField(name = "str")
+    private String str;
+
+    @DatabaseField(name = "arr")
+    private Set<Enumeration> array;
+
+    public String getStr() {
+        return str;
+    }
+
+    public void setStr(final String str) {
+        this.str = str;
+    }
+
+    public Set<Enumeration> getArray() {
+        return array;
+    }
+
+    public void setArray(final Set<Enumeration> array) {
+        this.array = array;
+    }
+}

--- a/src/test/java/com/typemapper/parser/postgres/ParseUtilsTest.java
+++ b/src/test/java/com/typemapper/parser/postgres/ParseUtilsTest.java
@@ -16,20 +16,17 @@ public class ParseUtilsTest {
 
     @Test(expected = ArrayParserException.class)
     public void testPostgresArray2StringListEmptyValue() throws ArrayParserException {
-        List<String> fieldValues;
-        fieldValues = ParseUtils.postgresArray2StringList("{a,}");
+        ParseUtils.postgresArray2StringList("{a,}");
     }
 
     @Test(expected = ArrayParserException.class)
     public void testPostgresArray2StringListEmptyValue2() throws ArrayParserException {
-        List<String> fieldValues;
-        fieldValues = ParseUtils.postgresArray2StringList("{,,}");
+        ParseUtils.postgresArray2StringList("{,,}");
     }
 
     @Test(expected = ArrayParserException.class)
     public void testPostgresArray2StringListEmptyValue3() throws ArrayParserException {
-        List<String> fieldValues;
-        fieldValues = ParseUtils.postgresArray2StringList("{a,,b}");
+        ParseUtils.postgresArray2StringList("{a,,b}");
     }
 
     @Test

--- a/src/test/java/com/typemapper/sproctest/SprocPrimitiveTest.java
+++ b/src/test/java/com/typemapper/sproctest/SprocPrimitiveTest.java
@@ -8,86 +8,89 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.typemapper.AbstractTest;
+
 import com.typemapper.core.TypeMapper;
 import com.typemapper.core.TypeMapperFactory;
 import com.typemapper.core.db.DbFunctionRegister;
+
 import com.typemapper.sproctest.result.ArrayResult;
 import com.typemapper.sproctest.result.PrimitiveResult;
 import com.typemapper.sproctest.result.PrimitiveResult2;
 
 public class SprocPrimitiveTest extends AbstractTest {
 
+    @Test
+    public void testPrimitives() throws SQLException {
+        connection.createStatement().execute("set search_path to tmp,tmp2");
 
-	
-	@Test
-	public void testPrimitives() throws SQLException {
-		connection.createStatement().execute("set search_path to tmp,tmp2");
-		final PreparedStatement ps = connection.prepareStatement("SELECT tmp.primitives_function();");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(PrimitiveResult.class);
-		int i = 0;
-		while( rs.next() ) {
-			PrimitiveResult result = (PrimitiveResult) mapper.mapRow(rs, i++);
-			Assert.assertEquals(0, result.getId().intValue());
-			Assert.assertEquals("result_code", result.getMsg());
-		}
-	}
-	
-	@Test
-	public void testPrimitivesWithNullString() throws SQLException {
-		connection.createStatement().execute("set search_path to tmp,tmp2");
-		final PreparedStatement ps = connection.prepareStatement("SELECT tmp.primitives_with_null_function();");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(PrimitiveResult.class);
-		int i = 0;
-		while( rs.next() ) {
-			PrimitiveResult result = (PrimitiveResult) mapper.mapRow(rs, i++);
-			Assert.assertEquals(0, result.getId().intValue());
-			Assert.assertNull(result.getMsg());
-		}
-	}	
-	
-	@Test
-	public void testPrimitivesWithSearchPath() throws SQLException {
-		connection.createStatement().execute("set search_path to tmp2,tmp");
-		DbFunctionRegister.reInitRegistry(connection);
-		final PreparedStatement ps = connection.prepareStatement("SELECT primitives_function();");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(PrimitiveResult2.class);
-		int i = 0;
-		while( rs.next() ) {
-			PrimitiveResult2 result = (PrimitiveResult2) mapper.mapRow(rs, i++);
-			Assert.assertEquals(0, result.getId().intValue());
-			Assert.assertEquals("result_code", result.getMsg());
-			Assert.assertEquals("result_code_2", result.getMsg2());
-		}
-	}	
-	
-	@Test
-	public void testObjectArray() throws SQLException {
-		connection.createStatement().execute("set search_path to tmp,tmp2");
-		DbFunctionRegister.reInitRegistry(connection);
-		final PreparedStatement ps = connection.prepareStatement("SELECT tmp.array_function();");
-		final ResultSet rs = ps.executeQuery();
-		final TypeMapper mapper = TypeMapperFactory.createTypeMapper(ArrayResult.class);
-		int i = 0;
-		while( rs.next() ) {
-			ArrayResult result = (ArrayResult) mapper.mapRow(rs, i++);
-			Assert.assertEquals(0, result.getId().intValue());
-			Assert.assertEquals("result_code", result.getMsg());
-			Assert.assertNotNull(result.getMovies());
-			Assert.assertEquals(3, result.getMovies().size());
-			Assert.assertEquals(1, result.getMovies().get(0).getI());
-			Assert.assertEquals(2, result.getMovies().get(0).getL());
-			Assert.assertEquals("Daniel", result.getMovies().get(0).getC());
-			Assert.assertEquals(2, result.getMovies().get(1).getI());
-			Assert.assertEquals(3, result.getMovies().get(1).getL());
-			Assert.assertEquals("alone at", result.getMovies().get(1).getC());
-			Assert.assertEquals(3, result.getMovies().get(2).getI());
-			Assert.assertEquals(4, result.getMovies().get(2).getL());
-			Assert.assertEquals("home", result.getMovies().get(2).getC());
-			
-			
-		}
-	}	
+        final PreparedStatement ps = connection.prepareStatement("SELECT tmp.primitives_function();");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(PrimitiveResult.class);
+        int i = 0;
+        while (rs.next()) {
+            final PrimitiveResult result = (PrimitiveResult) mapper.mapRow(rs, i++);
+            Assert.assertEquals(0, result.getId().intValue());
+            Assert.assertEquals("result_code", result.getMsg());
+        }
+    }
+
+    @Test
+    public void testPrimitivesWithNullString() throws SQLException {
+        connection.createStatement().execute("set search_path to tmp,tmp2");
+
+        final PreparedStatement ps = connection.prepareStatement("SELECT tmp.primitives_with_null_function();");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(PrimitiveResult.class);
+        int i = 0;
+        while (rs.next()) {
+            final PrimitiveResult result = (PrimitiveResult) mapper.mapRow(rs, i++);
+            Assert.assertEquals(0, result.getId().intValue());
+            Assert.assertNull(result.getMsg());
+        }
+    }
+
+    @Test
+    public void testPrimitivesWithSearchPath() throws SQLException {
+        connection.createStatement().execute("set search_path to tmp2,tmp");
+        DbFunctionRegister.reInitRegistry(connection);
+
+        final PreparedStatement ps = connection.prepareStatement("SELECT primitives_function();");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(PrimitiveResult2.class);
+        int i = 0;
+        while (rs.next()) {
+            final PrimitiveResult2 result = (PrimitiveResult2) mapper.mapRow(rs, i++);
+            Assert.assertEquals(0, result.getId().intValue());
+            Assert.assertEquals("result_code", result.getMsg());
+            Assert.assertEquals("result_code_2", result.getMsg2());
+        }
+    }
+
+    @Test
+    public void testObjectArray() throws SQLException {
+        connection.createStatement().execute("set search_path to tmp,tmp2");
+        DbFunctionRegister.reInitRegistry(connection);
+
+        final PreparedStatement ps = connection.prepareStatement("SELECT tmp.array_function();");
+        final ResultSet rs = ps.executeQuery();
+        final TypeMapper<?> mapper = TypeMapperFactory.createTypeMapper(ArrayResult.class);
+        int i = 0;
+        while (rs.next()) {
+            final ArrayResult result = (ArrayResult) mapper.mapRow(rs, i++);
+            Assert.assertEquals(0, result.getId().intValue());
+            Assert.assertEquals("result_code", result.getMsg());
+            Assert.assertNotNull(result.getMovies());
+            Assert.assertEquals(3, result.getMovies().size());
+            Assert.assertEquals(1, result.getMovies().get(0).getI());
+            Assert.assertEquals(2, result.getMovies().get(0).getL());
+            Assert.assertEquals("Daniel", result.getMovies().get(0).getC());
+            Assert.assertEquals(2, result.getMovies().get(1).getI());
+            Assert.assertEquals(3, result.getMovies().get(1).getL());
+            Assert.assertEquals("alone at", result.getMovies().get(1).getC());
+            Assert.assertEquals(3, result.getMovies().get(2).getI());
+            Assert.assertEquals(4, result.getMovies().get(2).getL());
+            Assert.assertEquals("home", result.getMovies().get(2).getC());
+
+        }
+    }
 }


### PR DESCRIPTION
You can use native postgres enumeration types in your sprocs.
When returning the enum type, it will be matched to the corresponding enum type in java.
You no longer need to convert the enums to text before returning its value.
