### PR TITLE
Added processing to respect transformer.marshalToDb

### DIFF
--- a/src/main/java/com/typemapper/core/db/DbTypeRegister.java
+++ b/src/main/java/com/typemapper/core/db/DbTypeRegister.java
@@ -48,10 +48,11 @@ public class DbTypeRegister {
                     "t.typarray > 0 as is_array " +
                     "from pg_type as t " +
                     "join pg_namespace as tn on t.typnamespace = tn.oid " +
+                    "left join pg_class c on t.typrelid = c.oid "+
                     "left join pg_attribute as a on a.attrelid = t.typrelid and a.attnum > 0 and not a.attisdropped " +
                     "left join pg_type as t2 on a.atttypid = t2.oid " +
                     "left join pg_namespace as tn2 on t2.typnamespace = tn2.oid " +
-                    "where t.typtype in ( 'c', 'e' ) " +
+                    "where (t.typtype = 'e' OR (t.typtype = 'c' AND c.relkind = 'c'::char))" +
                     "and tn.nspname not in ( 'pg_catalog', 'pg_toast', 'information_schema' ) " +
                     "and t.typowner > 0 " +
                     "order by t.typowner, type_schema, type_name, att_position");

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithSimpleTransformers.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithSimpleTransformers.java
@@ -1,0 +1,83 @@
+package com.typemapper.namedresult.results;
+
+import java.io.File;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.typemapper.annotations.DatabaseField;
+
+import com.typemapper.namedresult.transformer.FileTransformer;
+import com.typemapper.namedresult.transformer.GenderCodeIntegerTransformer;
+import com.typemapper.namedresult.transformer.GenderCodeTransformer;
+import com.typemapper.namedresult.transformer.StringListTransformer;
+
+public class ClassWithSimpleTransformers {
+
+    @DatabaseField(name = "gender_as_code", transformer = GenderCodeTransformer.class)
+    private GenderCode genderCode;
+
+    @DatabaseField(name = "gender_as_int", transformer = GenderCodeIntegerTransformer.class)
+    private GenderCode genderCodeAsInt;
+
+    @DatabaseField(name = "gender_as_name")
+    private GenderCode genderCodeAsName;
+
+    @DatabaseField(name = "file_column", transformer = FileTransformer.class)
+    private File file;
+
+    @DatabaseField(name = "string_list_with_separtion_char", transformer = StringListTransformer.class)
+    private List<String> stringList;
+
+    public ClassWithSimpleTransformers() { }
+
+    public ClassWithSimpleTransformers(final GenderCode genderCode, final GenderCode genderCodeAsInt,
+            final GenderCode genderCodeAsName, final String file, final String... stringList) {
+        this.genderCode = genderCode;
+        this.genderCodeAsInt = genderCodeAsInt;
+        this.genderCodeAsName = genderCodeAsName;
+        this.file = new File(file);
+
+        this.stringList = Arrays.asList(stringList);
+    }
+
+    public GenderCode getGenderCode() {
+        return genderCode;
+    }
+
+    public void setGenderCode(final GenderCode genderCode) {
+        this.genderCode = genderCode;
+    }
+
+    public GenderCode getGenderCodeAsInt() {
+        return genderCodeAsInt;
+    }
+
+    public void setGenderCodeAsInt(final GenderCode genderCodeAsInt) {
+        this.genderCodeAsInt = genderCodeAsInt;
+    }
+
+    public GenderCode getGenderCodeAsName() {
+        return genderCodeAsName;
+    }
+
+    public void setGenderCodeAsName(final GenderCode genderCodeAsName) {
+        this.genderCodeAsName = genderCodeAsName;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public void setFile(final File file) {
+        this.file = file;
+    }
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(final List<String> stringList) {
+        this.stringList = stringList;
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/transformer/FileTransformer.java
+++ b/src/test/java/com/typemapper/namedresult/transformer/FileTransformer.java
@@ -1,0 +1,18 @@
+package com.typemapper.namedresult.transformer;
+
+import java.io.File;
+
+import com.typemapper.core.ValueTransformer;
+
+public class FileTransformer extends ValueTransformer<String, File> {
+
+    @Override
+    public File unmarshalFromDb(final String value) {
+        return new File(value);
+    }
+
+    @Override
+    public String marshalToDb(final File bound) {
+        return bound.getPath();
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/transformer/GenderCodeIntegerTransformer.java
+++ b/src/test/java/com/typemapper/namedresult/transformer/GenderCodeIntegerTransformer.java
@@ -1,0 +1,18 @@
+package com.typemapper.namedresult.transformer;
+
+import com.typemapper.core.ValueTransformer;
+
+import com.typemapper.namedresult.results.GenderCode;
+
+public class GenderCodeIntegerTransformer extends ValueTransformer<Integer, GenderCode> {
+
+    @Override
+    public GenderCode unmarshalFromDb(final String value) {
+        return GenderCode.values()[Integer.valueOf(value)];
+    }
+
+    @Override
+    public Integer marshalToDb(final GenderCode bound) {
+        return bound.ordinal();
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/transformer/StringListTransformer.java
+++ b/src/test/java/com/typemapper/namedresult/transformer/StringListTransformer.java
@@ -1,0 +1,27 @@
+package com.typemapper.namedresult.transformer;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import com.typemapper.core.ValueTransformer;
+
+public class StringListTransformer extends ValueTransformer<String, List<String>> {
+
+    @Override
+    public List<String> unmarshalFromDb(final String value) {
+        return Arrays.asList(value.split("#"));
+    }
+
+    @Override
+    public String marshalToDb(final List<String> bound) {
+        String ret = "";
+        for (final String string : bound) {
+            ret += string + "#";
+        }
+
+        return StringUtils.trimTrailingCharacter(ret, '#');
+    }
+
+}

--- a/src/test/java/com/typemapper/postgres/PgSerializerToDatabaseTest.java
+++ b/src/test/java/com/typemapper/postgres/PgSerializerToDatabaseTest.java
@@ -32,7 +32,9 @@ import com.typemapper.AbstractTest;
 import com.typemapper.namedresult.results.ClassWithEnum;
 import com.typemapper.namedresult.results.ClassWithPrimitives;
 import com.typemapper.namedresult.results.ClassWithPrimitivesAndMap;
+import com.typemapper.namedresult.results.ClassWithSimpleTransformers;
 import com.typemapper.namedresult.results.Enumeration;
+import com.typemapper.namedresult.results.GenderCode;
 
 @RunWith(Parameterized.class)
 public class PgSerializerToDatabaseTest extends AbstractTest {
@@ -167,6 +169,14 @@ public class PgSerializerToDatabaseTest extends AbstractTest {
                         PgTypeHelper.asPGobject(new ClassWithEnum(Enumeration.VALUE_1, Enumeration.VALUE_2)),
                         "(VALUE_1,VALUE_2)", Types.OTHER
                     },
+
+                    /* 17 */
+                    {
+                        PgTypeHelper.asPGobject(
+                            new ClassWithSimpleTransformers(GenderCode.MALE, GenderCode.MALE, GenderCode.MALE, "path",
+                                "listElement1", "listElement2", "listElement3")),
+                        "(path,homme,0,MALE,listElement1#listElement2#listElement3)", Types.OTHER
+                    },
                 });
     }
 
@@ -184,6 +194,11 @@ public class PgSerializerToDatabaseTest extends AbstractTest {
 
         // type with positional members:
         execute("CREATE TYPE tmp.additional_type_with_positions AS (i int, l bigint, c text, h hstore);");
+
+        // type with gender code
+        execute("CREATE TYPE gender_enum_type AS ENUM ('MALE', 'FEMALE');");
+        execute(
+            "CREATE TYPE tmp.class_with_simple_transformers AS (file_column text, gender_as_code text, gender_as_int integer, gender_as_name gender_enum_type, string_list_with_separtion_char text);");
     }
 
     @After


### PR DESCRIPTION
New feature:

-> added processing to respect transformer.marshalToDb

Bug fix:

-> removed tables from type registry to avoid multiple types of same name.
-> would be a nice feature to use tables are "predefined" types for java domain objects, but it will be necessary to implement a fully qualified name for domain objects to address the correct type from the java domain object.
