### PR TITLE
Added new feature: global transformer registy

### DIFF
--- a/src/main/java/com/typemapper/core/TypeMapperFactory.java
+++ b/src/main/java/com/typemapper/core/TypeMapperFactory.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 
 import com.typemapper.core.db.DbFunctionRegister;
 import com.typemapper.core.db.DbTypeRegister;
+import com.typemapper.core.fieldMapper.GlobalValueTransformerRegistry;
 
 public class TypeMapperFactory {
 
@@ -19,5 +20,10 @@ public class TypeMapperFactory {
     public static void initTypeAndFunctionCaches(final Connection connection, final String name) throws SQLException {
         DbFunctionRegister.initRegistry(connection, name);
         DbTypeRegister.initRegistry(name, connection);
+    }
+
+    public static void registerGlobalValueTransformer(final Class<?> clazz,
+            final ValueTransformer<?, ?> valueTransformer) {
+        GlobalValueTransformerRegistry.register(clazz, valueTransformer);
     }
 }

--- a/src/main/java/com/typemapper/core/fieldMapper/GlobalValueTransformerRegistry.java
+++ b/src/main/java/com/typemapper/core/fieldMapper/GlobalValueTransformerRegistry.java
@@ -1,0 +1,19 @@
+package com.typemapper.core.fieldMapper;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.typemapper.core.ValueTransformer;
+
+public class GlobalValueTransformerRegistry {
+    private static final Map<Class<?>, ValueTransformer<?, ?>> register =
+        new ConcurrentHashMap<Class<?>, ValueTransformer<?, ?>>();
+
+    public static void register(final Class<?> clazz, final ValueTransformer<?, ?> valueTransformer) {
+        register.put(clazz, valueTransformer);
+    }
+
+    public static ValueTransformer<?, ?> getValueTransformerForClass(final Class<?> clazz) {
+        return register.get(clazz);
+    }
+}

--- a/src/main/java/com/typemapper/core/fieldMapper/ValueTransformerFieldMapper.java
+++ b/src/main/java/com/typemapper/core/fieldMapper/ValueTransformerFieldMapper.java
@@ -11,6 +11,10 @@ public class ValueTransformerFieldMapper implements FieldMapper {
         this.valueTransformer = valueTransformer.newInstance();
     }
 
+    public ValueTransformerFieldMapper(final ValueTransformer<?, ?> valueTransformer) {
+        this.valueTransformer = valueTransformer;
+    }
+
     @Override
     public Object mapField(final String string, final Class<?> clazz) {
         if (string == null) {

--- a/src/test/java/com/typemapper/namedresult/results/ClassWithPredefinedTransformer.java
+++ b/src/test/java/com/typemapper/namedresult/results/ClassWithPredefinedTransformer.java
@@ -1,0 +1,40 @@
+package com.typemapper.namedresult.results;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.typemapper.annotations.DatabaseField;
+
+import com.typemapper.namedresult.transformer.Hans;
+
+public class ClassWithPredefinedTransformer {
+
+    @DatabaseField
+    private Hans hans;
+
+    @DatabaseField
+    private List<Hans> hansList;
+
+    public ClassWithPredefinedTransformer() { }
+
+    public ClassWithPredefinedTransformer(final Hans hans, final Hans... hansList) {
+        this.hans = hans;
+        this.hansList = Arrays.asList(hansList);
+    }
+
+    public Hans getHans() {
+        return hans;
+    }
+
+    public void setHans(final Hans hans) {
+        this.hans = hans;
+    }
+
+    public List<Hans> getHansList() {
+        return hansList;
+    }
+
+    public void setHansList(final List<Hans> hansList) {
+        this.hansList = hansList;
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/transformer/Hans.java
+++ b/src/test/java/com/typemapper/namedresult/transformer/Hans.java
@@ -1,0 +1,26 @@
+package com.typemapper.namedresult.transformer;
+
+import com.typemapper.core.TypeMapperFactory;
+
+public class Hans {
+
+    static {
+        TypeMapperFactory.registerGlobalValueTransformer(Hans.class, new HansValueTransformer());
+    }
+
+    private Object value;
+
+    public Hans() { }
+
+    public Hans(final Object value) {
+        this.value = value;
+    }
+
+    public void setValue(final Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/src/test/java/com/typemapper/namedresult/transformer/HansValueTransformer.java
+++ b/src/test/java/com/typemapper/namedresult/transformer/HansValueTransformer.java
@@ -1,0 +1,16 @@
+package com.typemapper.namedresult.transformer;
+
+import com.typemapper.core.ValueTransformer;
+
+public class HansValueTransformer extends ValueTransformer<String, Hans> {
+
+    @Override
+    public Hans unmarshalFromDb(final String value) {
+        return new Hans(value);
+    }
+
+    @Override
+    public String marshalToDb(final Hans bound) {
+        return String.valueOf(bound.getValue());
+    }
+}

--- a/src/test/java/com/typemapper/postgres/PgSerializerToDatabaseTest.java
+++ b/src/test/java/com/typemapper/postgres/PgSerializerToDatabaseTest.java
@@ -30,11 +30,13 @@ import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import com.typemapper.AbstractTest;
 
 import com.typemapper.namedresult.results.ClassWithEnum;
+import com.typemapper.namedresult.results.ClassWithPredefinedTransformer;
 import com.typemapper.namedresult.results.ClassWithPrimitives;
 import com.typemapper.namedresult.results.ClassWithPrimitivesAndMap;
 import com.typemapper.namedresult.results.ClassWithSimpleTransformers;
 import com.typemapper.namedresult.results.Enumeration;
 import com.typemapper.namedresult.results.GenderCode;
+import com.typemapper.namedresult.transformer.Hans;
 
 @RunWith(Parameterized.class)
 public class PgSerializerToDatabaseTest extends AbstractTest {
@@ -177,6 +179,24 @@ public class PgSerializerToDatabaseTest extends AbstractTest {
                                 "listElement1", "listElement2", "listElement3")),
                         "(path,homme,0,MALE,listElement1#listElement2#listElement3)", Types.OTHER
                     },
+
+                    /* 18 */
+                    {
+                        PgTypeHelper.asPGobject(
+                            new ClassWithPredefinedTransformer(
+                                new Hans("This is a complex object using an implicit transformer."))),
+                        "(\"This is a complex object using an implicit transformer.\",{})", Types.OTHER
+                    },
+
+                    /* 19 */
+                    {
+                        PgTypeHelper.asPGobject(
+                            new ClassWithPredefinedTransformer(
+                                new Hans("This is a complex object using an implicit transformer."),
+                                new Hans("list element 1"), new Hans("list element 2"))),
+                        "(\"This is a complex object using an implicit transformer.\",\"{\"\"list element 1\"\",\"\"list element 2\"\"}\")",
+                        Types.OTHER
+                    },
                 });
     }
 
@@ -194,6 +214,9 @@ public class PgSerializerToDatabaseTest extends AbstractTest {
 
         // type with positional members:
         execute("CREATE TYPE tmp.additional_type_with_positions AS (i int, l bigint, c text, h hstore);");
+
+        // transformed type:
+        execute("CREATE TYPE tmp.class_with_predefined_transformer AS (a text, b text[]);");
 
         // type with gender code
         execute("CREATE TYPE gender_enum_type AS ENUM ('MALE', 'FEMALE');");


### PR DESCRIPTION
Using 

TypeMapperFactory.registerGlobalValueTransformer(Class<?> clazz, ValueTransformer<?, ?> valueTransformer);

you can register global transformations of types. 
All registered global transformer do not need a transformer entry in the @DatabaseField(transformer=...)
